### PR TITLE
Entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ micromouse = "sim.__main__:main"
 [project.gui-scripts]
 sim = "sim.gui:_main [gui]"
 
+[project.entry-points."micromouse.robot"]
+better_random = "sim.robots.random:better_random_robot"
+
 [project.optional-dependencies]
 gui = [
   "pygame==2.5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ micromouse = "sim.__main__:main"
 [project.gui-scripts]
 sim = "sim.gui:_main [gui]"
 
+[project.entry-points."micromouse.gui"]
+default = "sim.gui:GUIRenderer"
+
 [project.entry-points."micromouse.robot"]
 better_random = "sim.robots.random:better_random_robot"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ sim = "sim.gui:_main [gui]"
 [project.entry-points."micromouse.gui"]
 default = "sim.gui:GUIRenderer"
 
+[project.entry-points."micromouse.tool"]
+maze = "sim.tools:MazeEditor"
+
 [project.entry-points."micromouse.robot"]
 better_random = "sim.robots.random:better_random_robot"
 

--- a/sim/__init__.py
+++ b/sim/__init__.py
@@ -3,6 +3,6 @@
 TODO: document
 """
 
-from . import maze, simulator, gui
+from . import maze, simulator, gui, robots, unionfind
 
 __version__ = (0, 1, 0)

--- a/sim/__main__.py
+++ b/sim/__main__.py
@@ -14,54 +14,110 @@ from .front import (
     position_set,
     position,
     Renderer,
+    Tool,
 )
-from .maze import Maze
+from .maze import ExtendedMaze, Maze
 from .robots import idle_robot, load_robots
 from .robots.utils import walls_to_directions
 from .simulator import Simulator
 
 
-def _load_gui_engines() -> dict[str, type[Renderer]]:
+def __load_gui_engines() -> dict[str, type[Renderer]]:
     engines: dict[str, type[Renderer]] = {}
     for renderer in entry_points(group='micromouse.gui'):
         try:
             renderer_class = renderer.load()
         except (AttributeError, ImportError) as err:
-            print(f"warning: failed to load renderer {renderer.name}: {err}")
+            print(f"warning: failed to load renderer {renderer.name}: {err}", file=sys.stderr)
             continue
         if not issubclass(renderer_class, Renderer):
-            print(f"warning: failed to load renderer {renderer.name}: must inherit from {Renderer.__module__}.{Renderer.__qualname__}")
+            print(
+                f"warning: failed to load renderer {renderer.name}: must inherit from {Renderer.__module__}.{Renderer.__qualname__}",
+                file=sys.stderr,
+            )
             continue
         if renderer.name in engines:
             print(
                 f"warning: {renderer.name} from {renderer.module}:{renderer.attr} overrides "
-                f"{engines[renderer.name].__module__}:{engines[renderer.name].__qualname__}"
+                f"{engines[renderer.name].__module__}:{engines[renderer.name].__qualname__}",
+                file=sys.stderr,
             )
         engines[renderer.name] = renderer_class
     return engines
+
+
+def __build_tool_parser(main_parser: argparse.ArgumentParser) -> None:
+    tools = main_parser.add_subparsers(
+        title='tools',
+        description="All registered tools.",
+        required=True,
+    )
+
+    def __priority(module: str) -> tuple[int, str]:
+        return (int(not (bool(__package__) and module.startswith(f"{__package__}."))), module)
+
+    taken_names: dict[str, type[Tool]] = {}
+    for tool in sorted(entry_points(group='micromouse.tool'), key=lambda ep: __priority(ep.module)):
+        if tool.name in taken_names:
+            print(
+                f"warning: not loading {tool.name} from {tool.module}:{tool.attr}: would override "
+                f"{taken_names[tool.name].__module__}:{taken_names[tool.name].__qualname__}",
+                file=sys.stderr,
+            )
+            continue
+        try:
+            tool_class = tool.load()
+        except (AttributeError, ImportError) as err:
+            print(f"warning: failed to load tool {tool.name}: {err}", file=sys.stderr)
+            continue
+        if not issubclass(tool_class, Tool):
+            print(
+                f"warning: failed to load tool {tool.name}: must inherit from {Tool.__module__}.{Tool.__qualname__}",
+                file=sys.stderr,
+            )
+            continue
+
+        parser_args = tool_class.PARSER_ARGS.copy()
+
+        # Add load information to epilog
+        origin = f"Loaded from {tool.value}"
+        if epilog := parser_args.pop('epilog', None):
+            epilog += f"\n{origin}"
+        else:
+            epilog = origin
+        parser_args['epilog'] = epilog
+
+        # Fill description if needed
+        if not parser_args.get('description') and tool_class.__doc__:
+            parser_args['description'] = tool_class.__doc__
+
+        parser = tools.add_parser(
+            tool.name,
+            help=tool_class.__doc__ or f'{tool.module}:{tool.attr}',
+            **parser_args,
+        )
+        tool_class.build_parser(parser)
+        parser.set_defaults(tool_main=tool_class.main)
+
+        taken_names[tool.name] = tool_class
 
 
 def main():
     """
     The main entrypoint for the simulation, loads a simulation based on
     commandline arguments and triggers the selected renderer entrypoint.
-
-    TODO: allow more than just the gui entrypoint.
-    TODO: extended argument parser.
-    TODO: add utilities like maze template creator/viewer/validator/converter...
     """
     parser = argparse.ArgumentParser(
         description="Micromouse simulator.",
     )
     subparsers = parser.add_subparsers(
-        title='actions',
-        description="Different action modes.",
-        dest='action',
+        title='subcommands',
+        dest='main_action',
         required=True,
-        help="Different action modes ??.",
     )
     sim = subparsers.add_parser(
         'sim',
+        help="Run the simulator.",
         description="Run the simulator.",
     )
     sim.add_argument(
@@ -94,7 +150,7 @@ def main():
         presets_file='mazes/presets.json',
         help="A maze+start+goals preset to load.",
     )
-    gui_engines = _load_gui_engines()
+    gui_engines = __load_gui_engines()
     sim.add_argument(
         '-e', '--engine',
         choices=gui_engines,
@@ -102,46 +158,44 @@ def main():
         help="The render engine to use. (default: a simple pygame GUI renderer, requires the 'gui' feature)",
     )
 
+    tool = subparsers.add_parser(
+        'tool',
+        help="Run a tool.",
+        description="Run a tool.",
+    )
+    __build_tool_parser(tool)
+
     args = parser.parse_args()
-    if args.goals is None:
-        args.goals = {(args.maze.height - 1, args.maze.width - 1)}
-    if args.start_direction is None:
-        args.start_direction = (walls_to_directions(args.maze[args.start_pos]) or [Direction.NORTH])[0]
 
     load_robots()
 
     print(args)
 
-    if args.maze:
-        # Maze.render = '\n'.join(''.join(row) for row in self.render_screen(charset, cell_width, cell_height, force_corners)) + '\n'
-        screen = args.maze.render_screen()
-        start_row, start_col = args.start_pos
-        match args.start_direction:
-            case Direction.NORTH:
-                start_mark = '^'
-            case Direction.EAST:
-                start_mark = '>'
-            case Direction.SOUTH:
-                start_mark = 'v'
-            case Direction.WEST:
-                start_mark = '<'
-            case _:
-                start_mark = 'S'
-        screen[start_row * 2 + 1, start_col * 4 + 2] = start_mark
-        for (goal_row, goal_col) in args.goals:
-            screen[goal_row * 2 + 1, goal_col * 4 + 2] = '@'
-        print('\n'.join(''.join(row) for row in screen))
-        # print(args.maze.render(), end="")
-    else:
-        print("no maze")
-        sys.exit(1)
+    match args.main_action:
+        case 'sim':
+            if args.goals is None:
+                args.goals = {(args.maze.height - 1, args.maze.width - 1)}
+            if args.start_direction is None:
+                args.start_direction = (walls_to_directions(args.maze[args.start_pos]) or [Direction.NORTH])[0]
 
-    gui_engines[args.engine](Simulator(
-        alg=idle_robot,
-        maze=args.maze,
-        begin=args.start_pos + (args.start_direction,),
-        end=args.goals,
-    )).run()
+            if args.maze:
+                print(ExtendedMaze.full_from_maze(args.maze).render_extra(
+                    pos=args.start_pos + (args.start_direction,),
+                    goals=args.goals,
+                    weights=False,
+                ))
+            else:
+                print("no maze")
+                sys.exit(1)
+
+            gui_engines[args.engine](Simulator(
+                alg=idle_robot,
+                maze=args.maze,
+                begin=args.start_pos + (args.start_direction,),
+                end=args.goals,
+            )).run()
+        case 'tool':
+            args.tool_main(args)
 
 
 if __name__ == '__main__':

--- a/sim/__main__.py
+++ b/sim/__main__.py
@@ -14,7 +14,7 @@ from typing import TypedDict, TYPE_CHECKING
 from .directions import Direction
 from .maze import Maze
 from .gui import GUIRenderer  # TODO: change this to use the entrypoints syntax
-from .robots import idle_robot
+from .robots import idle_robot, load_robots
 from .robots.utils import walls_to_directions
 from .simulator import Simulator
 
@@ -262,6 +262,8 @@ def main():
         args.goals = {(args.maze.height - 1, args.maze.width - 1)}
     if args.start_direction is None:
         args.start_direction = (walls_to_directions(args.maze[args.start_pos]) or [Direction.NORTH])[0]
+
+    load_robots()
 
     print(args)
 

--- a/sim/__main__.py
+++ b/sim/__main__.py
@@ -2,206 +2,23 @@
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import re
 import sys
 
-from collections.abc import Set
 from importlib.metadata import entry_points
-from io import StringIO
-from typing import TypedDict, TYPE_CHECKING
 
 from .directions import Direction
-from .front import Renderer
+from .front import (
+    direction,
+    LoadPreset,
+    maze,
+    position_set,
+    position,
+    Renderer,
+)
 from .maze import Maze
 from .robots import idle_robot, load_robots
 from .robots.utils import walls_to_directions
 from .simulator import Simulator
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-
-def __maze_from_num(num: str) -> Maze:
-    return Maze.from_num_file(StringIO(num))
-
-
-def __maze_from_maz(maz: str) -> Maze:
-    if re.fullmatch(r'(?:\\x[a-fA-F0-9]{2}|\s)+', maz):
-        maz_bytes = bytes.fromhex(maz.replace('\\x', ''))
-    elif re.fullmatch(r'(?:0x[a-fA-F0-9]{1,2}\s*,?|\s|[\[\](){}])+', maz):
-        maz_bytes = bytes(int(byte, 16) for byte in re.sub(r'[\[\](){}\s]', '', maz).split(','))
-    elif re.fullmatch(r'(?:[a-fA-F0-9]{2}|\s)+', maz):
-        maz_bytes = bytearray.fromhex(maz)
-    elif all(0 <= ord(c) <= 0xF for c in maz):
-        maz_bytes = maz.encode(encoding="ASCII")
-    else:
-        raise argparse.ArgumentTypeError("invalid maz format")
-    return Maze.from_maz(maz_bytes)
-
-
-def __maze(arg: str) -> Maze:
-    """Maze type for argparse."""
-    typ = ''
-    if ':' in arg:
-        typ, sep, arg = arg.partition(':')
-        arg = arg.lstrip()
-        if not sep and not typ:
-            raise argparse.ArgumentTypeError("found ':' but maze type is empty")
-    match typ:
-        case 'maze' | '':
-            file_parser = Maze.from_file
-            text_parser = Maze.from_maze_text
-        case 'maz':
-            file_parser = Maze.from_maz_file
-            text_parser = __maze_from_maz
-        case 'num':
-            file_parser = Maze.from_num_file
-            text_parser = __maze_from_num
-        case 'csv':
-            file_parser = Maze.from_csv_file
-            text_parser = Maze.from_csv
-        case _:
-            raise argparse.ArgumentTypeError(f"unknown maze type: {typ!r}")
-    if arg == '-':
-        return text_parser(sys.stdin.read())
-    if typ and not os.path.exists(arg):
-        return text_parser(arg)
-    return file_parser(arg)  # type: ignore
-
-
-def maze(arg: str) -> Maze:
-    """Maze type for argparse."""
-    try:
-        return __maze(arg)
-    except Exception as error:
-        raise argparse.ArgumentTypeError(str(error))
-
-
-def position(arg: str) -> tuple[int, int]:
-    """position type for argparse."""
-    if m := re.fullmatch(r'(?P<open>\()?\s*(?P<row>\d+)\s*,\s*(?P<col>\d+)\s*(?(open)\)|)', arg):
-        return (int(m['row']), int(m['col']))
-    raise ValueError
-
-
-def position_set(arg: str) -> Set[tuple[int, int]]:
-    """position type for argparse."""
-    return {position(pos) for pos in arg.split(':')}
-
-
-def direction(arg: str) -> Direction:
-    """direction type for argparse."""
-    return Direction.from_str(arg)
-
-
-class Preset(TypedDict, total=True):
-    """A maze + starting point + goals preset."""
-    file: str
-    start_pos: tuple[int, int]
-    start_direction: Direction
-    goals: Set[tuple[int, int]]
-
-
-_PRESET_KEYS = frozenset(Preset.__annotations__)
-
-
-class LoadPreset(argparse.Action):
-    """Load a maze + starting point + goals preset.
-    """
-
-    def __init__(  # pylint: disable=too-many-arguments
-            self,
-            option_strings: Sequence[str],
-            dest: str,
-            default: str | None = None,
-            required: bool = False,
-            help: str | None = None,  # pylint: disable=redefined-builtin
-            metavar: str | tuple[str, ...] | None = None,
-            presets_file: str = 'presets.toml',
-    ) -> None:
-        self.presets: dict[str, Preset] | None = None
-        self.presets_file = presets_file
-        self.maze_dest, self.start_pos_dest, self.start_direction_dest, self.goal_dest = map(str.strip, dest.split(','))
-        super().__init__(
-            option_strings=option_strings,
-            dest=self.maze_dest,
-            default=default,
-            required=required,
-            help=help,
-            metavar=metavar,
-        )
-
-    def _load_presets(self, force: bool = False):
-        if self.presets and not force:
-            return
-
-        def _translate_pos(obj: object, main_name: str, name: str) -> tuple[int, int]:
-            if not isinstance(obj, list | tuple):
-                raise TypeError(f"in {main_name}: invalid type for '{name}': {type(obj).__name__}")
-            if len(obj) != 2:
-                raise TypeError(f"in {main_name}: invalid type for '{name}': expected 2 items, found {len(obj)}")
-            if not all(isinstance(v, int) for v in obj):
-                raise TypeError(
-                    f"in {main_name}: invalid type for '{name}': "
-                    f"expected ints, found {', '.join(type(v).__name__ for v in obj)}"
-                )
-            return tuple(obj)
-
-        def _translate(d: dict[str, object], name: str) -> Preset:
-            keys = frozenset(d)
-            if _PRESET_KEYS != keys:
-                if missing := _PRESET_KEYS - keys:
-                    raise TypeError(f"in {name}: missing keys: {', '.join(missing)}")
-                if extra := keys - _PRESET_KEYS:
-                    raise TypeError(f"in {name}: unexpected keys: {', '.join(extra)}")
-
-            if not isinstance(file := d.get('file'), str):
-                raise TypeError(f"invalid type for 'file': {type(file).__name__}")
-
-            start_pos = _translate_pos(d.get('start_pos'), name, 'start_pos')
-
-            if not isinstance(start_direction := d.get('start_direction'), str | Direction):
-                raise TypeError(f"invalid type for 'start_direction': {type(start_direction).__name__}")
-            if isinstance(start_direction, str):
-                start_direction = Direction.from_str(start_direction)
-
-            if not isinstance(goals := d.get('goals'), list | Set):
-                raise TypeError(f"invalid type for 'goals': {type(goals).__name__}")
-            goals = {_translate_pos(g, name, f'goals[{i}]') for i, g in enumerate(goals)}
-            return {'file': file, 'start_pos': start_pos, 'start_direction': start_direction, 'goals': goals}
-
-        with open(self.presets_file, encoding="utf-8") as presets_file:
-            raw_presets = json.load(presets_file)
-        if not isinstance(raw_presets, dict):
-            raise TypeError(f"invalid presets main object type: {type(raw_presets).__name__}")
-        self.presets = {
-            name: _translate(info, name)
-            for name, info in raw_presets.items()
-        }
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string not in self.option_strings:
-            return
-
-        try:
-            self._load_presets()
-        except Exception as err:
-            raise argparse.ArgumentError(self, f"failed to load presets: {err!s}")
-        assert self.presets is not None
-
-        if values not in self.presets:
-            raise argparse.ArgumentError(self, f"unknown preset: {values}")
-
-        preset = self.presets[values]
-        try:
-            setattr(namespace, self.maze_dest, maze(preset['file']))
-        except Exception as err:
-            raise argparse.ArgumentError(self, str(err))
-        setattr(namespace, self.start_pos_dest, preset['start_pos'])
-        setattr(namespace, self.start_direction_dest, preset['start_direction'])
-        setattr(namespace, self.goal_dest, preset['goals'])
 
 
 def _load_gui_engines() -> dict[str, type[Renderer]]:

--- a/sim/front.py
+++ b/sim/front.py
@@ -2,10 +2,22 @@
 """
 from __future__ import annotations
 
+import argparse
+import json
+import os
+import re
+import sys
+
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from collections.abc import Set
+from io import StringIO
+from typing import TypedDict, TYPE_CHECKING
+
+from .directions import Direction
+from .maze import Maze
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from .simulator import Simulator
 
 
@@ -20,3 +32,213 @@ class Renderer(ABC):  # pylint: disable=too-few-public-methods
     def run(self) -> None:
         """Start the renderer."""
         raise NotImplementedError
+
+
+def __maze_from_num(num: str) -> Maze:
+    return Maze.from_num_file(StringIO(num))
+
+
+def __maze_from_maz(maz: str) -> Maze:
+    if re.fullmatch(r'(?:\\x[a-fA-F0-9]{2}|\s)+', maz):
+        maz_bytes = bytes.fromhex(maz.replace('\\x', ''))
+    elif re.fullmatch(r'(?:0x[a-fA-F0-9]{1,2}\s*,?|\s|[\[\](){}])+', maz):
+        maz_bytes = bytes(int(byte, 16) for byte in re.sub(r'[\[\](){}\s]', '', maz).split(','))
+    elif re.fullmatch(r'(?:[a-fA-F0-9]{2}|\s)+', maz):
+        maz_bytes = bytearray.fromhex(maz)
+    elif all(0 <= ord(c) <= 0xF for c in maz):
+        maz_bytes = maz.encode(encoding="ASCII")
+    else:
+        raise argparse.ArgumentTypeError("invalid maz format")
+    return Maze.from_maz(maz_bytes)
+
+
+def __maze(arg: str) -> Maze:
+    typ = ''
+    if ':' in arg:
+        typ, sep, arg = arg.partition(':')
+        arg = arg.lstrip()
+        if not sep and not typ:
+            raise argparse.ArgumentTypeError("found ':' but maze type is empty")
+    match typ:
+        case '':
+            file_parser = Maze.from_file
+            text_parser = Maze.from_maze_text
+        case 'maze':
+            file_parser = Maze.from_maze_file
+            text_parser = Maze.from_maze_text
+        case 'maz':
+            file_parser = Maze.from_maz_file
+            text_parser = __maze_from_maz
+        case 'num':
+            file_parser = Maze.from_num_file
+            text_parser = __maze_from_num
+        case 'csv':
+            file_parser = Maze.from_csv_file
+            text_parser = Maze.from_csv
+        case _:
+            raise argparse.ArgumentTypeError(f"unknown maze type: {typ!r}")
+    if arg == '-':
+        return text_parser(sys.stdin.read())
+    if typ and not os.path.exists(arg):
+        return text_parser(arg)
+    return file_parser(arg)  # type: ignore
+
+
+def maze(arg: str) -> Maze:
+    """Maze type for argparse."""
+    try:
+        return __maze(arg)
+    except argparse.ArgumentTypeError:
+        raise
+    except Exception as error:
+        raise argparse.ArgumentTypeError(str(error))
+
+
+def position(arg: str) -> tuple[int, int]:
+    """Position type for argparse. A "position" is a tuple of (row, col) coordinates."""
+    if m := re.fullmatch(r'(?P<open>\()?\s*(?P<row>\d+)\s*,\s*(?P<col>\d+)\s*(?(open)\)|)', arg):
+        return (int(m['row']), int(m['col']))
+    raise ValueError
+
+
+def position_set(arg: str) -> Set[tuple[int, int]]:
+    """Position set type for argparse. A "position" is a tuple of (row, col) coordinates."""
+    return {position(pos) for pos in arg.split(':')}
+
+
+def direction(arg: str) -> Direction:
+    """Direction type for argparse."""
+    return Direction.from_str(arg)
+
+
+class Preset(TypedDict, total=True):
+    """A maze + starting point + goals preset."""
+    file: str
+    start_pos: tuple[int, int]
+    start_direction: Direction
+    goals: Set[tuple[int, int]]
+
+
+_PRESET_KEYS = frozenset(Preset.__annotations__)
+
+
+def __translate_pos(obj: object, main_name: str, name: str) -> tuple[int, int]:
+    if not isinstance(obj, list | tuple):
+        raise TypeError(f"in {main_name}: invalid type for '{name}': {type(obj).__name__}")
+    if len(obj) != 2:
+        raise TypeError(f"in {main_name}: invalid type for '{name}': expected 2 items, found {len(obj)}")
+    if not all(isinstance(v, int) for v in obj):
+        raise TypeError(
+            f"in {main_name}: invalid type for '{name}': "
+            f"expected ints, found {', '.join(type(v).__name__ for v in obj)}"
+        )
+    return tuple(obj)
+
+
+def __translate(d: dict[str, object], name: str) -> Preset:
+    keys = frozenset(d)
+    if _PRESET_KEYS != keys:
+        if missing := _PRESET_KEYS - keys:
+            raise TypeError(f"in {name}: missing keys: {', '.join(missing)}")
+        if extra := keys - _PRESET_KEYS:
+            raise TypeError(f"in {name}: unexpected keys: {', '.join(extra)}")
+
+    if not isinstance(file := d.get('file'), str):
+        raise TypeError(f"invalid type for 'file': {type(file).__name__}")
+
+    start_pos = __translate_pos(d.get('start_pos'), name, 'start_pos')
+
+    if not isinstance(start_direction := d.get('start_direction'), str | Direction):
+        raise TypeError(f"invalid type for 'start_direction': {type(start_direction).__name__}")
+    if isinstance(start_direction, str):
+        start_direction = Direction.from_str(start_direction)
+
+    if not isinstance(goals := d.get('goals'), list | Set):
+        raise TypeError(f"invalid type for 'goals': {type(goals).__name__}")
+    goals = {__translate_pos(g, name, f'goals[{i}]') for i, g in enumerate(goals)}
+    return {'file': file, 'start_pos': start_pos, 'start_direction': start_direction, 'goals': goals}
+
+
+def load_presets(presets_json_file: str) -> dict[str, Preset]:
+    """Load maze presets from a presets JSON file.
+
+    Args:
+        presets_json_file (str): The path to the file to load.
+
+    Raises:
+        OSError: On errors when opening the file.
+        json.decoder.JSONDecodeError: On errors parsing the JSON.
+        TypeError: If the JSON is in an incorrect format (bad types).
+        ValueError: If a field has an invalid value (i.e.: non-existent start_direction).
+
+    Returns:
+        dict[str, Preset]: The parsed presets.
+    """
+    with open(presets_json_file, encoding="utf-8") as presets_file:
+        raw_presets = json.load(presets_file)
+    if not isinstance(raw_presets, dict):
+        raise TypeError(f"invalid presets main object type: {type(raw_presets).__name__}")
+
+    return {
+        name: __translate(info, name)
+        for name, info in raw_presets.items()
+    }
+
+
+class LoadPreset(argparse.Action):
+    """An argparse action that loads a maze + starting point + goals preset.
+
+    The ``dest`` param should be a comma-separated string with the format of:
+    "{maze_dest},{starting_point_dest},{start_direction_dest}"
+    (additional whitespaces are allowed)
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            option_strings: Sequence[str],
+            dest: str,
+            default: str | None = None,
+            required: bool = False,
+            help: str | None = None,  # pylint: disable=redefined-builtin
+            metavar: str | tuple[str, ...] | None = None,
+            presets_file: str = 'presets.json',
+    ) -> None:
+        self.presets: dict[str, Preset] | None = None
+        self.presets_file = presets_file
+        self.maze_dest, self.start_pos_dest, self.start_direction_dest, self.goal_dest = map(str.strip, dest.split(','))
+        super().__init__(
+            option_strings=option_strings,
+            dest=self.maze_dest,
+            default=default,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+    def _load_presets(self, force: bool = False):
+        if self.presets and not force:
+            return
+
+        self.presets = load_presets(self.presets_file)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string not in self.option_strings:
+            return
+
+        try:
+            self._load_presets()
+        except Exception as err:
+            raise argparse.ArgumentError(self, f"failed to load presets: {err!s}")
+        assert self.presets is not None
+
+        if values not in self.presets:
+            raise argparse.ArgumentError(self, f"unknown preset: {values}")
+
+        preset = self.presets[values]
+        try:
+            setattr(namespace, self.maze_dest, maze(preset['file']))
+        except Exception as err:
+            raise argparse.ArgumentError(self, str(err))
+        setattr(namespace, self.start_pos_dest, preset['start_pos'])
+        setattr(namespace, self.start_direction_dest, preset['start_direction'])
+        setattr(namespace, self.goal_dest, preset['goals'])

--- a/sim/front.py
+++ b/sim/front.py
@@ -1,0 +1,22 @@
+"""Utilities for using frontends this package.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .simulator import Simulator
+
+
+class Renderer(ABC):  # pylint: disable=too-few-public-methods
+    """Base renderer class for simulation (GUI) renderers."""
+
+    def __init__(self, sim: Simulator) -> None:
+        super().__init__()
+        self.sim = sim
+
+    @abstractmethod
+    def run(self) -> None:
+        """Start the renderer."""
+        raise NotImplementedError

--- a/sim/gui.py
+++ b/sim/gui.py
@@ -12,6 +12,7 @@ from os import environ
 from typing import Iterable, NamedTuple, Self
 
 from .directions import Direction, RelativeDirection
+from .front import Renderer
 from .maze import ExtraCellInfo, ExtendedMaze, Maze, Walls
 from .robots import (
     ROBOTS,
@@ -43,7 +44,7 @@ class Position(NamedTuple):
         return type(self)(self.row + other.row, self.col + other.col)
 
 
-class GUIRenderer:  # pylint: disable=too-many-instance-attributes
+class GUIRenderer(Renderer):  # pylint: disable=too-many-instance-attributes
     """Class for rendering the GUI on screen"""
 
     def __init__(self, sim: Simulator):
@@ -52,6 +53,8 @@ class GUIRenderer:  # pylint: disable=too-many-instance-attributes
         Args:
             sim (Simulator): The simulation to show.
         """
+        super().__init__(sim)
+
         pg.init()
         initial_screen_size = (1280, 720)
         screen = pg.display.set_mode(initial_screen_size, pg.RESIZABLE)
@@ -108,7 +111,6 @@ class GUIRenderer:  # pylint: disable=too-many-instance-attributes
         )
 
         self.sim_auto_step = True
-        self.sim = sim
 
         self.screen_width, self.screen_height = initial_screen_size
         self.text_size = 4 * min(self.screen_width, self.screen_height) // 100
@@ -550,9 +552,9 @@ class GUIRenderer:  # pylint: disable=too-many-instance-attributes
 def _main():
     sim = Simulator(
         alg=idle_robot,
-        maze=Maze.from_file('mazes/simple.maze'),
-        begin=(0, 0, Direction.SOUTH),
-        end={(1, 2)},
+        maze=Maze.from_file('mazes/semifinal_2010.maze'),
+        begin=(15, 0, Direction.EAST),
+        end={(7, 7), (7, 8), (8, 7), (8, 8)},
     )
 
     GUIRenderer(sim).run()

--- a/sim/gui.py
+++ b/sim/gui.py
@@ -14,6 +14,7 @@ from typing import Iterable, NamedTuple, Self
 from .directions import Direction, RelativeDirection
 from .maze import ExtraCellInfo, ExtendedMaze, Maze, Walls
 from .robots import (
+    ROBOTS,
     basic_weighted_flood_fill,
     idle_robot,
     random_robot,
@@ -29,17 +30,6 @@ environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 import pygame as pg  # pylint: disable=wrong-import-order,wrong-import-position
 import pygame_gui    # pylint: disable=wrong-import-order,wrong-import-position
 # autopep8: on
-
-
-ROBOTS = {
-    'Idle': idle_robot,
-    'Random': random_robot,
-    'Left Wall Follower': wall_follower_robot(RelativeDirection.LEFT),
-    'Right Wall Follower': wall_follower_robot(RelativeDirection.RIGHT),
-    'Flood Fill': simple_flood_fill,
-    'Flood Fill -> Dijkstra': basic_weighted_flood_fill,
-    'Thourough Flood Fill': thorough_flood_fill,
-}
 
 
 class Position(NamedTuple):

--- a/sim/gui.py
+++ b/sim/gui.py
@@ -13,7 +13,14 @@ from typing import Iterable, NamedTuple, Self
 
 from .directions import Direction, RelativeDirection
 from .maze import ExtraCellInfo, ExtendedMaze, Maze, Walls
-from .robots import basic_weighted_flood_fill, idle_robot, random_robot, simple_flood_fill, thorough_flood_fill, wall_follower_robot
+from .robots import (
+    basic_weighted_flood_fill,
+    idle_robot,
+    random_robot,
+    simple_flood_fill,
+    thorough_flood_fill,
+    wall_follower_robot,
+)
 from .simulator import SimulationStatus, Simulator
 
 # Disable the prompt triggered by importing `pygame`.

--- a/sim/maze.py
+++ b/sim/maze.py
@@ -94,6 +94,48 @@ class Walls(Flag):
         """
         return self.rotate_right(4 - (n & 0x3))  # ``n`` bits to the left == ``-(n % 4)`` bits to the right
 
+    def transpose(self) -> Self:
+        """Transpose the wall spec. (Swap: N <-> W, S <-> E)
+
+        Returns:
+            Self: The transposed walls.
+        """
+        nw = (self & Walls.NORTH).value ^ ((self & Walls.WEST).value >> 3)
+        se = ((self & Walls.SOUTH).value >> 2) ^ ((self & Walls.EAST).value >> 1)
+        mask = Walls((nw << 3) | (se << 2) | (se << 1) | nw)
+        return self ^ mask
+
+    def secondary_transpose(self) -> Self:
+        """Transpose the wall spec along the secondary axis. (Swap: N <-> E, S <-> W)
+
+        Returns:
+            Self: The transposed walls.
+        """
+        ne = (self & Walls.NORTH).value ^ ((self & Walls.EAST).value >> 1)
+        sw = ((self & Walls.SOUTH).value >> 2) ^ ((self & Walls.WEST).value >> 3)
+        mask = Walls((sw << 3) | (sw << 2) | (ne << 1) | ne)
+        return self ^ mask
+
+    def flip_horizontally(self) -> Self:
+        """Invert the wall spec horizontally. (Swap: E <-> W)
+
+        Returns:
+            Self: The inverted walls.
+        """
+        ew = ((self & Walls.EAST).value >> 1) ^ ((self & Walls.WEST).value >> 3)
+        mask = Walls((ew << 3) | (ew << 1))
+        return self ^ mask
+
+    def flip_vertically(self) -> Self:
+        """Invert the wall spec vertically. (Swap: N <-> S)
+
+        Returns:
+            Self: The inverted walls.
+        """
+        ns = (self & Walls.NORTH).value ^ ((self & Walls.SOUTH).value >> 2)
+        mask = Walls((ns << 2) | ns)
+        return self ^ mask
+
 
 class LineDirection(Flag):
     """Direction for the lines in the borders of a maze."""

--- a/sim/maze.py
+++ b/sim/maze.py
@@ -67,6 +67,33 @@ class Walls(Flag):
         """Return a wall specification for all possible walls."""
         return ~cls.none()
 
+    def rotate_right(self, n: int = 1) -> Self:
+        """Rotate the walls, ``n`` 90-degree turns to the right.
+
+        Args:
+            n (int, optional): The amount of 90-degree turns. Defaults to 1.
+
+        Returns:
+            Walls: The rotated walls.
+        """
+        n &= 0x3  # n %= 4  <- 4-bit rotate is noop
+        shifted = self.value << n
+        assert shifted <= 0x7F
+        hi = shifted & 0xF0
+        lo = shifted & 0x0F
+        return type(self)(lo | (hi >> 4))
+
+    def rotate_left(self, n: int = 1) -> Self:
+        """Rotate the walls, ``n`` 90-degree turns to the left.
+
+        Args:
+            n (int, optional): The amount of 90-degree turns. Defaults to 1.
+
+        Returns:
+            Walls: The rotated walls.
+        """
+        return self.rotate_right(4 - (n & 0x3))  # ``n`` bits to the left == ``-(n % 4)`` bits to the right
+
 
 class LineDirection(Flag):
     """Direction for the lines in the borders of a maze."""

--- a/sim/robots/__init__.py
+++ b/sim/robots/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import const, flood_fill, idle, random, wall_follower
+from . import const, flood_fill, idle, random, utils, wall_follower
 from .const import predetermined_robot
 from .flood_fill import simple_flood_fill, basic_weighted_flood_fill, thorough_flood_fill
 from .idle import idle_robot
@@ -27,3 +27,5 @@ from .wall_follower import wall_follower_robot
 
 if TYPE_CHECKING:
     from .utils import Algorithm, Robot
+
+del TYPE_CHECKING

--- a/sim/robots/__init__.py
+++ b/sim/robots/__init__.py
@@ -15,7 +15,8 @@ Advanced:
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from functools import cache
+from typing import overload, TYPE_CHECKING
 
 from . import const, flood_fill, idle, random, utils, wall_follower
 from .const import predetermined_robot
@@ -25,7 +26,91 @@ from .random import random_robot
 from .utils import Action, RobotState
 from .wall_follower import wall_follower_robot
 
+from ..directions import RelativeDirection
+
 if TYPE_CHECKING:
+    from typing import Callable
     from .utils import Algorithm, Robot
 
-del TYPE_CHECKING
+ROBOTS: dict[str, Algorithm] = {
+    'Idle': idle_robot,
+    'Random': random_robot,
+    'Left Wall Follower': wall_follower_robot(RelativeDirection.LEFT),
+    'Right Wall Follower': wall_follower_robot(RelativeDirection.RIGHT),
+    'Flood Fill': simple_flood_fill,
+    'Flood Fill -> Dijkstra': basic_weighted_flood_fill,
+    'Thorough Flood Fill': thorough_flood_fill,
+}
+
+
+@overload
+def register_robot(name: str, robot: Algorithm) -> Algorithm: ...
+@overload
+def register_robot(name: str, robot: None = None) -> Callable[[Algorithm], Algorithm]: ...
+
+
+def register_robot(name: str, robot: Algorithm | None = None) -> Algorithm | Callable[[Algorithm], Algorithm]:
+    """Register a robot to the robot registry.
+
+    Args:
+        name (str): A nice name for the robot, used to identify the robot.
+        robot (Algorithm | None, optional):
+            The robot's algorithm, if omitted, this function returns a decorator that registers
+            the robot. Defaults to None.
+
+    Returns:
+        Algorithm | Callable[[Algorithm], Algorithm]:
+            ``robot`` if robot is not ``None``, otherwise, a decorator that accepts an Algorithm,
+            registers it and returns it.
+
+    >>> def my_robot(maze, goals):
+    ...     yield Action.READY
+    ...     yield Action.FORWARD
+    >>> _ = register_robot('My Robot', my_robot)
+    >>> ROBOTS.get('My Robot') is my_robot
+    True
+    >>> @register_robot('My Spinner')
+    ... def my_spinner(maze, goals):
+    ...     yield Action.READY
+    ...     while True:
+    ...         yield Action.TURN_LEFT
+    >>> ROBOTS.get('My Spinner') is my_spinner
+    True
+    """
+    def _decorator(robot: Algorithm) -> Algorithm:
+        ROBOTS[name] = robot
+        return robot
+
+    if robot is None:
+        return _decorator
+    return _decorator(robot)
+
+
+@cache
+def load_robots() -> None:
+    """Load all robots registered as an entrypoint.
+    """
+    import re  # pylint: disable=import-outside-toplevel
+    from importlib.metadata import entry_points  # pylint: disable=import-outside-toplevel
+    from types import ModuleType  # pylint: disable=import-outside-toplevel
+
+    def capitalize_match(m: re.Match[str]) -> str:
+        return m.group().capitalize()
+
+    for robot in entry_points(group='micromouse.robot'):
+        try:
+            alg = robot.load()
+        except (AttributeError, ImportError) as err:
+            print(f"warning: failed to load robot {robot.name}: {err}")
+            continue
+        if isinstance(alg, ModuleType):
+            continue
+        pretty_name = re.sub(r'\w+', capitalize_match, robot.name.replace('_', ' '))
+        module = m.group() if (m := re.match(r'[^:.]+', robot.value)) else robot.value
+        register_robot(f"{pretty_name} ({module})", alg)
+
+
+if TYPE_CHECKING:
+    del Callable
+
+del RelativeDirection, annotations, cache, overload, TYPE_CHECKING

--- a/sim/robots/random.py
+++ b/sim/robots/random.py
@@ -61,3 +61,57 @@ def random_robot(maze: Maze, goals: Set[tuple[int, int]]) -> Robot:
     # Victory dance
     while utils.ENABLE_VICTORY_DANCE:
         yield random.choice((Action.TURN_LEFT, Action.TURN_RIGHT))
+
+
+def better_random_robot(maze: Maze, goals: Set[tuple[int, int]]) -> Robot:
+    """
+    A robot with random movements that will not return to the previous cell unless
+    it has to.
+
+    Returns:
+        Robot: The robot's brain.
+    """
+    print(f"randomouse: starting in a {maze.height}x{maze.width} maze")
+    print(f"randomouse: aiming for {goals}")
+    pos_row, pos_col, heading = yield Action.READY
+    print(f"randomouse: starting at {(pos_row, pos_col)} facing {heading}")
+
+    while (pos_row, pos_col) not in goals:
+        walls = maze[pos_row, pos_col]
+        print(f"randomouse: at {(pos_row, pos_col)} facing {heading} with {walls}")
+        choices = walls_to_directions(walls)
+        if len(choices) > 1:
+            choices.remove(heading.turn_back())
+        new_direction = random.choice(choices)
+        print(f"randomouse: chose to migrate {new_direction}")
+        if new_direction == heading:
+            print("randomouse: will move forward")
+        elif new_direction == heading.turn_back():
+            print("randomouse: will retreat")
+            turn_action = random.choice([Action.TURN_LEFT, Action.TURN_RIGHT])
+            for _ in range(2):
+                r, c, heading = yield turn_action
+                assert (r, c) == (pos_row, pos_col), "randomouse: moved while turning"
+                assert maze[r, c] == walls, "randomouse: walls changed while turning"
+            assert heading == new_direction, "randomouse: turning failed"
+            print(f"randomouse: now facing {heading}, will move forward")
+        else:
+            if new_direction == heading.turn_left():
+                print("randomouse: turning left")
+                turn_action = Action.TURN_LEFT
+            elif new_direction == heading.turn_right():
+                print("randomouse: turning right")
+                turn_action = Action.TURN_RIGHT
+            else:
+                raise AssertionError(f"invalid turn from {heading} to {new_direction}")
+            r, c, heading = yield turn_action
+            assert (r, c) == (pos_row, pos_col), "randomouse: moved while turning"
+            assert maze[r, c] == walls, "randomouse: walls changed while turning"
+            assert heading == new_direction, "randomouse: turning failed"
+            print(f"randomouse: now facing {heading}, will move forward")
+        pos_row, pos_col, heading = yield Action.FORWARD
+
+    print("randomouse: victory")
+    # Victory dance
+    while utils.ENABLE_VICTORY_DANCE:
+        yield random.choice((Action.TURN_LEFT, Action.TURN_RIGHT))

--- a/sim/simulator.py
+++ b/sim/simulator.py
@@ -232,6 +232,7 @@ class Simulator:  # pylint: disable=too-many-instance-attributes
             case Action.RESET:
                 print("sim: robot asked for reset")
                 if self._robot_pos[:-1] != self._begin[:-1] or self._status is not SimulationStatus.IN_PROGRESS_FOUND_DEST:
+                    self._status = SimulationStatus.ERROR
                     raise RuntimeError("reset must be done from the starting position and after finding the goal")
                 self._maze.reset_info()
                 self._robot_pos = self._begin

--- a/sim/simulator.py
+++ b/sim/simulator.py
@@ -174,7 +174,7 @@ class Simulator:  # pylint: disable=too-many-instance-attributes
         print(f"sim: restarting with a {self.maze.height}x{self.maze.width} maze")
         print(f"sim: robot will start at {self._begin[:-1]} facing {self._begin[-1]}")
         self._maze.reset_info()
-        self._robot_maze = ExtendedMaze.empty(self._maze.height, self.maze.width)
+        self._robot_maze = ExtendedMaze.empty(self.maze.height, self.maze.width)
         self._robot_pos = self._begin
 
         self._robot = alg(self._robot_maze, self._end)

--- a/sim/tools.py
+++ b/sim/tools.py
@@ -1,0 +1,405 @@
+"""Example tools.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from typing import Literal, TextIO
+
+from .front import (
+    maze as maze_type,
+    size as size_type,
+    Tool,
+)
+from .maze import (
+    ascii_charset,
+    Charset,
+    Maze,
+    utf8_charset,
+    Walls,
+)
+
+
+class MazeEditor(Tool):
+    """Utilities for viewing and manipulating a maze."""
+
+    @classmethod
+    def build_parser(cls, parser: argparse.ArgumentParser) -> None:
+        subcommands = parser.add_subparsers(
+            title='subcommands',
+            dest='maze_command',
+            required=True,
+        )
+
+        generate = subcommands.add_parser(
+            'generate',
+            help="Generate a new maze.",
+            description="Generate a new maze.",
+        )
+        generate.add_argument(
+            'output_file',
+            type=argparse.FileType("wt", encoding="utf-8"),
+            help="The path to save the new maze at ('-' for stdout).",
+        )
+        generate.add_argument(
+            '-s', '--size',
+            type=size_type,
+            default="16x16",
+            help="The size of the maze to create. (default: 16x16)",
+        )
+        gen_methods = generate.add_mutually_exclusive_group()
+        gen_methods.add_argument(
+            '--empty',
+            action='store_const',
+            const='empty',
+            dest='gen_method',
+            help="Generate an empty maze (no walls).",
+        )
+        gen_methods.add_argument(
+            '--full',
+            action='store_const',
+            const='full',
+            dest='gen_method',
+            help="Generate a full maze (all walls). (default)",
+        )
+        generate.set_defaults(gen_method='full')
+
+        render = subcommands.add_parser(
+            'render',
+            help="Render a maze (can be used to convert other formats into .maze format).",
+            description="Render a maze.",
+        )
+        render.add_argument(
+            'maze',
+            type=maze_type,
+            help="The maze to load. May be a file or a maze input.",
+        )
+        render.add_argument(
+            '-A', '--ascii',
+            action='store_const',
+            const=ascii_charset,
+            dest='charset',
+            help="Use ASCII characters to draw the maze. (default)",
+        )
+        render.add_argument(
+            '-U', '--unicode',
+            action='store_const',
+            const=utf8_charset,
+            dest='charset',
+            help="Use Unicode (UTF-8) characters to draw the maze.",
+        )
+        render.add_argument(
+            '--cell-width',
+            type=int,
+            default=3,
+            help="The amount of characters between to cell corners horizontally. (default: 3).",
+        )
+        render.add_argument(
+            '--cell-height',
+            type=int,
+            default=1,
+            help="The amount of characters between to cell corners vertically. (default: 1).",
+        )
+        render.add_argument(
+            '--no-force-corners',
+            action='store_false',
+            dest='force_corners',
+            help="Don't draw corners between cells where no walls are attached.",
+        )
+        render.add_argument(
+            '-o', '--output-file',
+            type=argparse.FileType("wt", encoding="utf-8"),
+            default='-',
+            help="Render the maze into a file. Use '-' for stdout. (default: stdout)",
+        )
+        render.set_defaults(charset=ascii_charset)
+
+        rotate = subcommands.add_parser(
+            'rotate',
+            help="Rotate a maze (can be used to convert other formats into .maze format).",
+            description="Rotate a maze.",
+        )
+        rotate.add_argument(
+            'maze',
+            type=maze_type,
+            help="The maze to load. May be a file or a maze input.",
+        )
+        rotate.add_argument(
+            '-o', '--output-file',
+            type=argparse.FileType("wt", encoding="utf-8"),
+            default='-',
+            help="Rotate the maze into a file. Use '-' for stdout. (default: stdout)",
+        )
+        direction = rotate.add_mutually_exclusive_group()
+        direction.add_argument(
+            '-l', '--left',
+            action='store_const',
+            const='left',
+            dest='direction',
+            help="Rotate the maze to the left (counter-clockwise).",
+        )
+        direction.add_argument(
+            '-r', '--right',
+            action='store_const',
+            const='right',
+            dest='direction',
+            help="Rotate the maze to the right (clockwise). (default)",
+        )
+        rotate.set_defaults(direction='right')
+        rotate.add_argument(
+            '-n', '--rotations',
+            type=int,
+            default=1,
+            help="The number of 90-degree rotations to apply. (default: 1)",
+        )
+
+        transpose = subcommands.add_parser(
+            'transpose',
+            help="Transpose a maze.",
+            description="Transpose a maze.",
+        )
+        transpose.add_argument(
+            'maze',
+            type=maze_type,
+            help="The maze to load. May be a file or a maze input.",
+        )
+        transpose.add_argument(
+            '-o', '--output-file',
+            type=argparse.FileType("wt", encoding="utf-8"),
+            default='-',
+            help="Transpose the maze into a file. Use '-' for stdout. (default: stdout)",
+        )
+        transpose.add_argument(
+            '-s', '--secondary-diagonal',
+            action='store_const',
+            const='secondary',
+            default='primary',
+            dest='diagonal',
+            help="Transpose the maze along the secondary diagonal. (default: primary diagonal)",
+        )
+
+        flip = subcommands.add_parser(
+            'flip',
+            help="Flip a maze.",
+            description="Flip a maze.",
+        )
+        flip.add_argument(
+            'maze',
+            type=maze_type,
+            help="The maze to load. May be a file or a maze input.",
+        )
+        flip.add_argument(
+            '-o', '--output-file',
+            type=argparse.FileType("wt", encoding="utf-8"),
+            default='-',
+            help="Flip the maze into a file. Use '-' for stdout. (default: stdout)",
+        )
+        flip.add_argument(
+            '-a', '--axis',
+            choices=['horizontal', 'vertical'],
+            help="The axis to flip.",
+        )
+
+    @classmethod
+    def main(cls, args: argparse.Namespace) -> None:
+        match args.maze_command:
+            case 'generate':
+                cls.generate(
+                    output=args.output_file,
+                    size=args.size,
+                    method=args.gen_method,
+                )
+            case 'render':
+                cls.render(
+                    maze=args.maze,
+                    charset=args.charset,
+                    cell_size=(args.cell_height, args.cell_width),
+                    force_corners=args.force_corners,
+                    output=args.output_file,
+                )
+            case 'rotate':
+                cls.rotate(
+                    maze=args.maze,
+                    direction=args.direction,
+                    n=args.rotations,
+                    output=args.output_file,
+                )
+            case 'transpose':
+                cls.transpose(
+                    maze=args.maze,
+                    diagonal=args.diagonal,
+                    output=args.output_file,
+                )
+            case 'flip':
+                cls.flip(
+                    maze=args.maze,
+                    axis=args.axis,
+                    output=args.output_file,
+                )
+            case _:
+                print(f"unknown command: {args.maze_command}", file=sys.stderr)
+                sys.exit(1)
+
+    @staticmethod
+    def generate(
+            output: TextIO,
+            size: tuple[int, int] = (16, 16),
+            method: Literal['empty', 'full'] = 'full',
+    ) -> None:
+        """Generate a new maze.
+
+        Args:
+            output (TextIO): The file to render the maze into. Defaults to stdout.
+            size (tuple[int, int], optional): _description_. Defaults to (16, 16).
+            method (Literal['empty', 'full']): Generation method. Defaults to 'full'.
+            charset (Charset): Character set to use. Defaults to ASCII.
+        """
+        match method:
+            case 'empty':
+                func = Maze.empty
+            case 'full':
+                func = Maze.full
+            case _:
+                raise ValueError(f"unexpected method: {method!r}")
+
+        output.write(func(*size).render())
+
+    @staticmethod
+    def render(
+            maze: Maze,
+            charset: Charset = ascii_charset,
+            cell_size: tuple[int, int] = (1, 3),
+            force_corners: bool = True,
+            output: TextIO = sys.stdout,
+    ) -> None:
+        """Render a maze.
+
+        Args:
+            maze (Maze): The maze to render.
+            charset (Charset): Character set to use. Defaults to ASCII.
+            cell_size (tuple[int, int]): A (height, width) tuple of the amount of characters between 2 corners. Defaults to (1, 3).
+            force_corners (bool): Draw corners, even if no walls ar attached. Defaults to True.
+            output (TextIO): The file to render the maze into. Defaults to stdout.
+        """
+        output.write(maze.render(
+            charset=charset,
+            cell_height=cell_size[0],
+            cell_width=cell_size[1],
+            force_corners=force_corners,
+        ))
+
+    @staticmethod
+    def rotate(
+            maze: Maze,
+            direction: Literal['left', 'right'],
+            n: int = 1,
+            output: TextIO = sys.stdout,
+    ) -> None:
+        """Rotate a maze.
+
+        Args:
+            maze (Maze): The maze to render.
+            direction (Literal['left', 'right']): Direction to rotate.
+            n (int): Amount of 90-degree rotations to apply. Defaults to 1.
+            output (TextIO): The file to render the maze into. Defaults to stdout.
+        """
+        match direction:
+            case 'left':
+                rotate_cell = Walls.rotate_left
+                reduced_n = (4 - (n & 0x3)) & 0x3  # (4 - n) % 4
+            case 'right':
+                rotate_cell = Walls.rotate_right
+                reduced_n = n & 0x3  # n % 4
+            case _:
+                raise ValueError(f"unknown direction: {direction!r}")
+
+        match reduced_n:
+            case 0:  # No rotation
+                def _rotate_pos(row: int, col: int) -> tuple[int, int]:
+                    return (row, col)
+            case 1:  # Rotate right
+                def _rotate_pos(row: int, col: int) -> tuple[int, int]:
+                    return (col, maze.height - 1 - row)
+            case 2:  # Rotate 180
+                def _rotate_pos(row: int, col: int) -> tuple[int, int]:
+                    return (maze.height - 1 - row, maze.width - 1 - col)
+            case 3:  # Rotate left
+                def _rotate_pos(row: int, col: int) -> tuple[int, int]:
+                    return (maze.width - 1 - col, row)
+            case _:
+                raise AssertionError(f"bad modulus calculation (got {n!r})")
+
+        # For odd rotations, maze size swaps the dimensions
+        result = Maze.empty(*(maze.size[::-1] if n & 1 else maze.size))
+        for (row, col, cell) in maze:
+            result[_rotate_pos(row, col)] = rotate_cell(cell, n)
+
+        output.write(result.render())
+
+    @staticmethod
+    def transpose(
+            maze: Maze,
+            diagonal: Literal['primary', 'secondary'] = 'primary',
+            output: TextIO = sys.stdout,
+    ) -> None:
+        """Transpose a maze.
+
+        Args:
+            maze (Maze): The maze to transpose.
+            diagonal (Literal['primary', 'secondary']): Diagonal to transpose. Defaults to 'primary'.
+            output (TextIO): The file to save the maze at. Defaults to stdout.
+        """
+        match diagonal:
+            case 'primary':
+                transpose_cell = Walls.transpose
+
+                def _transpose_pos(row: int, col: int) -> tuple[int, int]:
+                    return col, row
+            case 'secondary':
+                transpose_cell = Walls.secondary_transpose
+
+                def _transpose_pos(row: int, col: int) -> tuple[int, int]:
+                    return maze.width - 1 - col, maze.height - 1 - row
+            case _:
+                raise ValueError(f"unexpected diagonal: {diagonal!r}")
+
+        # For odd rotations, maze size swaps the dimensions
+        result = Maze.empty(*maze.size[::-1])
+        for (row, col, cell) in maze:
+            result[_transpose_pos(row, col)] = transpose_cell(cell)
+
+        output.write(result.render())
+
+    @staticmethod
+    def flip(
+            maze: Maze,
+            axis: Literal['horizontal', 'vertical'],
+            output: TextIO = sys.stdout,
+    ) -> None:
+        """Flip a maze.
+
+        Args:
+            maze (Maze): The maze to flip.
+            direction (Literal['horizontal', 'vertical']): Direction to flip.
+            output (TextIO): The file to save the maze at. Defaults to stdout.
+        """
+        match axis:
+            case 'horizontal':
+                flip_cell = Walls.flip_horizontally
+
+                def _flip_pos(row: int, col: int) -> tuple[int, int]:
+                    return row, maze.width - 1 - col
+            case 'vertical':
+                flip_cell = Walls.flip_vertically
+
+                def _flip_pos(row: int, col: int) -> tuple[int, int]:
+                    return maze.height - 1 - row, col
+            case _:
+                raise ValueError(f"unexpected axis: {axis!r}")
+
+        result = Maze.empty(*maze.size)
+        for (row, col, cell) in maze:
+            result[_flip_pos(row, col)] = flip_cell(cell)
+
+        output.write(result.render())

--- a/tests/test_walls.py
+++ b/tests/test_walls.py
@@ -1,0 +1,161 @@
+# pylint: disable=missing-function-docstring,missing-module-docstring
+from __future__ import annotations
+
+from itertools import chain
+
+import pytest
+
+from sim.maze import Walls
+
+
+@pytest.mark.parametrize("walls,byte", [
+    pytest.param(Walls(0), b'\x00', id="empty"),
+    pytest.param(Walls.NORTH, b'\x01', id="north"),
+    pytest.param(Walls.EAST, b'\x02', id="east"),
+    pytest.param(Walls.SOUTH, b'\x04', id="south"),
+    pytest.param(Walls.WEST, b'\x08', id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, b'\x03', id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, b'\x05', id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, b'\x09', id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, b'\x06', id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, b'\x0a', id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, b'\x0c', id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, b'\x07', id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, b'\x0b', id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, b'\x0d', id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, b'\x0e', id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, b'\x0f', id="all"),
+])
+def test_bytes_conversions(walls: Walls, byte: bytes):
+    assert bytes(walls) == walls.to_bytes() == byte
+    assert Walls.from_bytes(byte) == walls
+
+
+def test_from_bytes_too_long():
+    with pytest.raises(ValueError):
+        Walls.from_bytes(b'\x0a\x04')
+
+
+def test_from_bytes_empty():
+    with pytest.raises(ValueError):
+        Walls.from_bytes(b'')
+
+
+def test_none():
+    none = Walls.none()
+    for wall in Walls:
+        assert wall not in none
+    assert Walls.none() == Walls(0)
+
+
+def test_all():
+    all_ = Walls.all()
+    for wall in Walls:
+        assert wall in all_
+    assert all_ == Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST
+
+
+@pytest.mark.parametrize("walls,rotated", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.EAST, id="north"),
+    pytest.param(Walls.EAST, Walls.SOUTH, id="east"),
+    pytest.param(Walls.SOUTH, Walls.WEST, id="south"),
+    pytest.param(Walls.WEST, Walls.NORTH, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.EAST | Walls.SOUTH, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.EAST | Walls.WEST, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.NORTH | Walls.EAST, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.SOUTH | Walls.WEST, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.NORTH | Walls.SOUTH, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.NORTH | Walls.WEST, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.NORTH, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.WEST, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.SOUTH, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.EAST, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_rotate_right(walls: Walls, rotated: Walls):
+    assert walls.rotate_right() == rotated
+    assert walls.rotate_right(n=1) == rotated
+    assert walls.rotate_left(n=3) == rotated
+    assert walls.rotate_left(n=-1) == rotated
+
+
+@pytest.mark.parametrize("walls,rotated", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.WEST, id="north"),
+    pytest.param(Walls.EAST, Walls.NORTH, id="east"),
+    pytest.param(Walls.SOUTH, Walls.EAST, id="south"),
+    pytest.param(Walls.WEST, Walls.SOUTH, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.NORTH | Walls.WEST, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.EAST | Walls.WEST, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.SOUTH | Walls.WEST, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.NORTH | Walls.EAST, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.NORTH | Walls.SOUTH, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.EAST | Walls.SOUTH, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.SOUTH, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.EAST, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.NORTH, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.WEST, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_rotate_left(walls: Walls, rotated: Walls):
+    assert walls.rotate_left() == rotated
+    assert walls.rotate_left(n=1) == rotated
+    assert walls.rotate_right(n=3) == rotated
+    assert walls.rotate_right(n=-1) == rotated
+
+
+@pytest.mark.parametrize("walls,rotated", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.SOUTH, id="north"),
+    pytest.param(Walls.EAST, Walls.WEST, id="east"),
+    pytest.param(Walls.SOUTH, Walls.NORTH, id="south"),
+    pytest.param(Walls.WEST, Walls.EAST, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.SOUTH | Walls.WEST, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.NORTH | Walls.SOUTH, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.EAST | Walls.SOUTH, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.NORTH | Walls.WEST, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.EAST | Walls.WEST, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.NORTH | Walls.EAST, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.EAST, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.NORTH, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.WEST, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.SOUTH, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_rotate_180(walls: Walls, rotated: Walls):
+    assert walls.rotate_right(n=2) == rotated
+    assert walls.rotate_left(n=2) == rotated
+
+
+@pytest.mark.parametrize("walls", [
+    pytest.param(Walls(0), id="empty"),
+    pytest.param(Walls.NORTH, id="north"),
+    pytest.param(Walls.EAST, id="east"),
+    pytest.param(Walls.SOUTH, id="south"),
+    pytest.param(Walls.WEST, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, id="all"),
+])
+def test_wraparound(walls: Walls):
+    right = walls.rotate_right()
+    flip = walls.rotate_right(2)
+    left = walls.rotate_left()
+    for i in chain((-1000,), range(-10, 10), (1000,)):
+        assert walls.rotate_right(4 * i) == walls
+        assert walls.rotate_right(4 * i + 1) == right
+        assert walls.rotate_right(4 * i + 2) == flip
+        assert walls.rotate_right(4 * i + 3) == left
+        assert walls.rotate_left(4 * i) == walls
+        assert walls.rotate_left(4 * i + 1) == left
+        assert walls.rotate_left(4 * i + 2) == flip
+        assert walls.rotate_left(4 * i + 3) == right

--- a/tests/test_walls.py
+++ b/tests/test_walls.py
@@ -159,3 +159,91 @@ def test_wraparound(walls: Walls):
         assert walls.rotate_left(4 * i + 1) == left
         assert walls.rotate_left(4 * i + 2) == flip
         assert walls.rotate_left(4 * i + 3) == right
+
+
+@pytest.mark.parametrize("walls,transposed", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.WEST, id="north"),
+    pytest.param(Walls.EAST, Walls.SOUTH, id="east"),
+    pytest.param(Walls.SOUTH, Walls.EAST, id="south"),
+    pytest.param(Walls.WEST, Walls.NORTH, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.SOUTH | Walls.WEST, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.EAST | Walls.WEST, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.NORTH | Walls.WEST, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.EAST | Walls.SOUTH, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.NORTH | Walls.SOUTH, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.NORTH | Walls.EAST, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.NORTH, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.EAST, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.SOUTH, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.WEST, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_transpose(walls: Walls, transposed: Walls):
+    assert walls.transpose() == transposed
+
+
+@pytest.mark.parametrize("walls,transposed", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.EAST, id="north"),
+    pytest.param(Walls.EAST, Walls.NORTH, id="east"),
+    pytest.param(Walls.SOUTH, Walls.WEST, id="south"),
+    pytest.param(Walls.WEST, Walls.SOUTH, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.NORTH | Walls.EAST, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.EAST | Walls.WEST, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.EAST | Walls.SOUTH, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.NORTH | Walls.WEST, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.NORTH | Walls.SOUTH, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.SOUTH | Walls.WEST, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.SOUTH, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.WEST, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.NORTH, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.EAST, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_secondary_transpose(walls: Walls, transposed: Walls):
+    assert walls.secondary_transpose() == transposed
+
+
+@pytest.mark.parametrize("walls,transposed", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.NORTH, id="north"),
+    pytest.param(Walls.EAST, Walls.WEST, id="east"),
+    pytest.param(Walls.SOUTH, Walls.SOUTH, id="south"),
+    pytest.param(Walls.WEST, Walls.EAST, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.NORTH | Walls.WEST, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.NORTH | Walls.SOUTH, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.NORTH | Walls.EAST, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.SOUTH | Walls.WEST, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.EAST | Walls.WEST, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.EAST | Walls.SOUTH, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.EAST, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.SOUTH, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.WEST, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.NORTH, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_flip_horizontally(walls: Walls, transposed: Walls):
+    assert walls.flip_horizontally() == transposed
+
+
+@pytest.mark.parametrize("walls,transposed", [
+    pytest.param(Walls(0), Walls.none(), id="empty"),
+    pytest.param(Walls.NORTH, Walls.SOUTH, id="north"),
+    pytest.param(Walls.EAST, Walls.EAST, id="east"),
+    pytest.param(Walls.SOUTH, Walls.NORTH, id="south"),
+    pytest.param(Walls.WEST, Walls.WEST, id="west"),
+    pytest.param(Walls.NORTH | Walls.EAST, Walls.EAST | Walls.SOUTH, id="north-east"),
+    pytest.param(Walls.NORTH | Walls.SOUTH, Walls.NORTH | Walls.SOUTH, id="north-south"),
+    pytest.param(Walls.NORTH | Walls.WEST, Walls.SOUTH | Walls.WEST, id="north-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH, Walls.NORTH | Walls.EAST, id="east-south"),
+    pytest.param(Walls.EAST | Walls.WEST, Walls.EAST | Walls.WEST, id="east-west"),
+    pytest.param(Walls.SOUTH | Walls.WEST, Walls.NORTH | Walls.WEST, id="south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH, ~Walls.WEST, id="north-east-south"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.WEST, ~Walls.NORTH, id="north-east-west"),
+    pytest.param(Walls.NORTH | Walls.SOUTH | Walls.WEST, ~Walls.EAST, id="north-south-west"),
+    pytest.param(Walls.EAST | Walls.SOUTH | Walls.WEST, ~Walls.SOUTH, id="east-south-west"),
+    pytest.param(Walls.NORTH | Walls.EAST | Walls.SOUTH | Walls.WEST, Walls.all(), id="all"),
+])
+def test_flip_vertically(walls: Walls, transposed: Walls):
+    assert walls.flip_vertically() == transposed


### PR DESCRIPTION
* Add `micromouse.robot` entry point for registering additional robots.
* Add `register_robot()` decorator for registering additional robots.
* Add `micromouse.gui` entry point for registering alternative GUI engines (maybe even TUI engines).
* Add `micromouse.tool` entry point for registering additional tools.
* Add `better_random`, a random robot that goes back only if necessary and doesn't drive in reverse. (Example for `micromouse.robot` entry point.)
* Modify `GUIRenderer` to use the `micromouse.gui` entry point.
* Add functions that rotate/transpose/flip `Walls` (and tests).
* Add `MazeEditor` example tool that can render/rotate/transpose/flip/generate mazes.